### PR TITLE
Replace deprecated create_function

### DIFF
--- a/inc/class-ipt-kb-affix-widget.php
+++ b/inc/class-ipt-kb-affix-widget.php
@@ -309,11 +309,10 @@ class IPT_KB_Affix_Widget extends WP_Widget {
 	}
 }
 
-//UTC MOD 2/17/21 create_function() depreciated START
-//add_action( 'widgets_init', create_function( '', "register_widget( 'IPT_KB_Affix_Widget' );" ) );
-
-add_action( 'widgets_init', function() { register_widget( "IPT_KB_Affix_Widget" ); } );
-//UTC MOD 2/17/21 create_function() depreciated END
+add_action( 'widgets_init', 'itkbaffix_register_widgets' );
+function itkbaffix_register_widgets() {
+    register_widget( 'IPT_KB_Affix_Widget' );
+}
 
 /**
  * TOC content filter

--- a/inc/class-ipt-kb-affix-widget.php
+++ b/inc/class-ipt-kb-affix-widget.php
@@ -309,11 +309,7 @@ class IPT_KB_Affix_Widget extends WP_Widget {
 	}
 }
 
-//UTC MOD 2/17/21 create_function() depreciated START
-//add_action( 'widgets_init', create_function( '', "register_widget( 'IPT_KB_Affix_Widget' );" ) );
-
 add_action( 'widgets_init', function() { register_widget( "IPT_KB_Affix_Widget" ); } );
-//UTC MOD 2/17/21 create_function() depreciated END
 
 /**
  * TOC content filter

--- a/inc/class-ipt-kb-affix-widget.php
+++ b/inc/class-ipt-kb-affix-widget.php
@@ -309,10 +309,11 @@ class IPT_KB_Affix_Widget extends WP_Widget {
 	}
 }
 
-add_action( 'widgets_init', 'itkbaffix_register_widgets' );
-function itkbaffix_register_widgets() {
-    register_widget( 'IPT_KB_Affix_Widget' );
-}
+//UTC MOD 2/17/21 create_function() depreciated START
+//add_action( 'widgets_init', create_function( '', "register_widget( 'IPT_KB_Affix_Widget' );" ) );
+
+add_action( 'widgets_init', function() { register_widget( "IPT_KB_Affix_Widget" ); } );
+//UTC MOD 2/17/21 create_function() depreciated END
 
 /**
  * TOC content filter

--- a/inc/class-ipt-kb-affix-widget.php
+++ b/inc/class-ipt-kb-affix-widget.php
@@ -309,7 +309,11 @@ class IPT_KB_Affix_Widget extends WP_Widget {
 	}
 }
 
-add_action( 'widgets_init', create_function( '', "register_widget( 'IPT_KB_Affix_Widget' );" ) );
+//UTC MOD 2/17/21 create_function() depreciated START
+//add_action( 'widgets_init', create_function( '', "register_widget( 'IPT_KB_Affix_Widget' );" ) );
+
+add_action( 'widgets_init', function() { register_widget( "IPT_KB_Affix_Widget" ); } );
+//UTC MOD 2/17/21 create_function() depreciated END
 
 /**
  * TOC content filter

--- a/inc/class-ipt-kb-knowledgebase-widget.php
+++ b/inc/class-ipt-kb-knowledgebase-widget.php
@@ -144,4 +144,4 @@ class IPT_KB_KnowledgeBase_Widget extends WP_Widget {
 	}
 }
 
-add_action( 'widgets_init', create_function( '', "register_widget( 'IPT_KB_KnowledgeBase_Widget' );" ) );
+add_action( 'widgets_init', function() { register_widget( "IPT_KB_KnowledgeBase_Widget" ); } );

--- a/inc/class-ipt-kb-popular-widget.php
+++ b/inc/class-ipt-kb-popular-widget.php
@@ -125,4 +125,4 @@ class IPT_KB_Popular_Widget extends WP_Widget {
 	}
 }
 
-add_action( 'widgets_init', create_function( '', "register_widget( 'IPT_KB_Popular_Widget' );" ) );
+add_action( 'widgets_init', function() { register_widget( "IPT_KB_Popular_Widget" ); } );

--- a/inc/class-ipt-kb-social-widget.php
+++ b/inc/class-ipt-kb-social-widget.php
@@ -142,4 +142,4 @@ class IPT_KB_Social_Widget extends WP_Widget {
 	}
 }
 
-add_action( 'widgets_init', create_function( '', "register_widget( 'IPT_KB_Social_Widget' );" ) );
+add_action( 'widgets_init', function() { register_widget( "IPT_KB_Social_Widget" ); } );


### PR DESCRIPTION
"This function internally performs an [eval()](https://www.php.net/manual/en/function.eval.php) and as such has the same security issues as [eval()](https://www.php.net/manual/en/function.eval.php). Additionally it has bad performance and memory usage characteristics.

A native [anonymous function](https://www.php.net/manual/en/functions.anonymous.php) should be used instead."
- https://www.php.net/manual/en/function.create-function.php#:~:text=This%20function%20has%20been%20DEPRECATED,this%20function%20is%20highly%20discouraged.
